### PR TITLE
feat: add movie management and recommendation services with AI

### DIFF
--- a/src/main/java/com/leiber/play/domain/dto/MovieDto.java
+++ b/src/main/java/com/leiber/play/domain/dto/MovieDto.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record MovieDto(
+        Long id,
         String title,
         Integer duration,
         Genre genre,

--- a/src/main/java/com/leiber/play/domain/dto/SuggestRequestDto.java
+++ b/src/main/java/com/leiber/play/domain/dto/SuggestRequestDto.java
@@ -1,0 +1,4 @@
+package com.leiber.play.domain.dto;
+
+public record SuggestRequestDto(String userPreferences) {
+}

--- a/src/main/java/com/leiber/play/domain/dto/UpdateMovieDto.java
+++ b/src/main/java/com/leiber/play/domain/dto/UpdateMovieDto.java
@@ -1,0 +1,11 @@
+package com.leiber.play.domain.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record UpdateMovieDto(
+        String title,
+        LocalDate releaseDate,
+        BigDecimal rating
+) {
+}

--- a/src/main/java/com/leiber/play/domain/repository/MovieRepository.java
+++ b/src/main/java/com/leiber/play/domain/repository/MovieRepository.java
@@ -1,9 +1,18 @@
 package com.leiber.play.domain.repository;
 
 import com.leiber.play.domain.dto.MovieDto;
+import com.leiber.play.domain.dto.UpdateMovieDto;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MovieRepository {
     List<MovieDto> getAll();
+
+    MovieDto getById(Long id);
+
+    MovieDto save(MovieDto movieDto);
+
+    MovieDto update(Long id, UpdateMovieDto movieDto);
+    Optional<MovieDto> delete(Long id);
 }

--- a/src/main/java/com/leiber/play/domain/service/LeiberPlayAiService.java
+++ b/src/main/java/com/leiber/play/domain/service/LeiberPlayAiService.java
@@ -1,5 +1,6 @@
 package com.leiber.play.domain.service;
 
+import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import dev.langchain4j.service.spring.AiService;
@@ -12,4 +13,11 @@ public interface LeiberPlayAiService {
                Usa menos de 120 caracteres y hazlo con el estilo de Alibaba
             """)
     String generateGreeting(@V("platform") String platform);
+
+    @SystemMessage("""
+            Eres un experto en cine que recomienda películas personalizadas según los gustos del usuario.
+            Debes recomendar máximo 3 películas.
+            No incluyas películas que estén por fuera de la plataforma {{platform}}
+            """)
+    String generateMoviesSuggestion(@V("platform") String platform, @UserMessage String userMessage);
 }

--- a/src/main/java/com/leiber/play/domain/service/MovieService.java
+++ b/src/main/java/com/leiber/play/domain/service/MovieService.java
@@ -1,7 +1,9 @@
 package com.leiber.play.domain.service;
 
 import com.leiber.play.domain.dto.MovieDto;
+import com.leiber.play.domain.dto.UpdateMovieDto;
 import com.leiber.play.domain.repository.MovieRepository;
+import dev.langchain4j.agent.tool.Tool;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -14,7 +16,24 @@ public class MovieService {
         this.movieRepository = movieRepository;
     }
 
+    @Tool("Busca todas las películas que existan dentro de la plataforma")
     public List<MovieDto> getAll() {
         return this.movieRepository.getAll();
+    }
+
+    public MovieDto getById(Long id) {
+        return this.movieRepository.getById(id);
+    }
+
+    public MovieDto save(MovieDto movieDto) {
+        return this.movieRepository.save(movieDto);
+    }
+
+    public MovieDto update(Long id, UpdateMovieDto updateMovieDto) {
+        return this.movieRepository.update(id, updateMovieDto);
+    }
+
+    public MovieDto delete(Long id) {
+        return this.movieRepository.delete(id).orElse(null);
     }
 }

--- a/src/main/java/com/leiber/play/persistence/MovieEntityRepository.java
+++ b/src/main/java/com/leiber/play/persistence/MovieEntityRepository.java
@@ -1,12 +1,15 @@
 package com.leiber.play.persistence;
 
 import com.leiber.play.domain.dto.MovieDto;
+import com.leiber.play.domain.dto.UpdateMovieDto;
 import com.leiber.play.domain.repository.MovieRepository;
 import com.leiber.play.persistence.crud.CrudMovieEntity;
+import com.leiber.play.persistence.entity.MovieEntity;
 import com.leiber.play.persistence.mapper.MovieMapper;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class MovieEntityRepository implements MovieRepository {
@@ -22,5 +25,38 @@ public class MovieEntityRepository implements MovieRepository {
     @Override
     public List<MovieDto> getAll() {
         return this.movieMapper.toDto(this.crudMovieEntity.findAll());
+    }
+
+    @Override
+    public MovieDto getById(Long id) {
+        MovieEntity movieEntity = this.crudMovieEntity.findById(id).orElse(null);
+        return this.movieMapper.toDto(movieEntity);
+    }
+
+    @Override
+    public MovieDto save(MovieDto movieDto) {
+        MovieEntity movieEntity = this.movieMapper.toEntity(movieDto);
+        return this.movieMapper.toDto(this.crudMovieEntity.save(movieEntity));
+    }
+
+    @Override
+    public MovieDto update(Long id, UpdateMovieDto updateMovieDto) {
+        MovieEntity movieEntity = this.crudMovieEntity.findById(id).orElse(null);
+
+        if (movieEntity == null) {
+            return null;
+        }
+
+        this.movieMapper.updateEntityFromDto(updateMovieDto, movieEntity);
+
+        return this.movieMapper.toDto(this.crudMovieEntity.save(movieEntity));
+    }
+
+    @Override
+    public Optional<MovieDto> delete(Long id) {
+        Optional<MovieEntity> movieEntity = this.crudMovieEntity.findById(id);
+
+        movieEntity.ifPresent(this.crudMovieEntity::delete);
+        return Optional.ofNullable(this.movieMapper.toDto(movieEntity.orElse(null)));
     }
 }

--- a/src/main/java/com/leiber/play/persistence/entity/MovieEntity.java
+++ b/src/main/java/com/leiber/play/persistence/entity/MovieEntity.java
@@ -78,4 +78,12 @@ public class MovieEntity {
     public void setEstado(String estado) {
         this.estado = estado;
     }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
 }

--- a/src/main/java/com/leiber/play/persistence/mapper/MovieMapper.java
+++ b/src/main/java/com/leiber/play/persistence/mapper/MovieMapper.java
@@ -1,9 +1,12 @@
 package com.leiber.play.persistence.mapper;
 
 import com.leiber.play.domain.dto.MovieDto;
+import com.leiber.play.domain.dto.UpdateMovieDto;
 import com.leiber.play.persistence.entity.MovieEntity;
+import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 import java.util.List;
 
@@ -19,4 +22,14 @@ public interface MovieMapper {
     MovieDto toDto(MovieEntity movieEntity);
 
     List<MovieDto> toDto(Iterable<MovieEntity> entities);
+
+    @InheritInverseConfiguration
+    @Mapping(source = "genre", target = "genero", qualifiedByName = "genreToString")
+    @Mapping(source = "state", target = "estado", qualifiedByName = "booleanToString")
+    MovieEntity toEntity(MovieDto movieDto);
+
+    @Mapping(target = "titulo", source = "title")
+    @Mapping(target = "fechaEstreno", source = "releaseDate")
+    @Mapping(target = "clasificacion", source = "rating")
+    void updateEntityFromDto(UpdateMovieDto updateMovieDto, @MappingTarget MovieEntity movieEntity);
 }


### PR DESCRIPTION
Add services for movie management, including reading, modifying, and deleting, as well as an AI-powered recommendation service to recommend existing movies.

- Add DTOs and mappers needed for the new features
- Create read, modify, and delete services for movies
- Implement AI-powered recommendation service
- Modify Movie entity to map to id field
- Update repository to support the new operations